### PR TITLE
Adding getCoinDetails in the API service

### DIFF
--- a/FullNode.UI/src/app/login/login.component.ts
+++ b/FullNode.UI/src/app/login/login.component.ts
@@ -113,8 +113,21 @@ export class LoginComponent implements OnInit {
   public onDecryptClicked() {
     this.isDecrypting = true;
     this.globalService.setWalletName(this.openWalletForm.get("selectWallet").value);
-    this.globalService.setCoinName("TestStratis");
-    this.globalService.setCoinUnit("TSTRAT");
+
+    this.apiService.getCoinDetails().subscribe(response => {
+      if (response.status >= 200 && response.status < 400){}
+        var coinDetails = response.json();
+        this.globalService.setCoinName(coinDetails.name);
+        this.globalService.setCoinUnit(coinDetails.symbol);
+      },
+      error => {
+        if(error.status === 404) console.log("no sidechain api found, defaulting to STRAT coin")
+        else console.log(error)
+        this.globalService.setCoinName("TestStratis");
+        this.globalService.setCoinUnit("TSTRAT");
+      }
+    )
+
     this.getCurrentNetwork();
     let walletLoad = new WalletLoad(
       this.openWalletForm.get("selectWallet").value,

--- a/FullNode.UI/src/app/shared/pipes/coin-notation.pipe.ts
+++ b/FullNode.UI/src/app/shared/pipes/coin-notation.pipe.ts
@@ -53,6 +53,9 @@ export class CoinNotationPipe implements PipeTransform {
         case "TuSTRAT":
           temp = value / 100;
           return temp.toFixed(this.decimalLimit);
+        default:
+          temp = value / 1.0
+          return temp.toFixed(this.decimalLimit)
       }
     }
   }

--- a/FullNode.UI/src/app/shared/services/api.service.ts
+++ b/FullNode.UI/src/app/shared/services/api.service.ts
@@ -88,6 +88,12 @@ export class ApiService {
         .map((response: Response) => response);
     }
 
+    getCoinDetails() : Observable<any> {
+      return this.http
+        .get(this.stratisApiUrl + '/sidechains/get-coindetails')
+        .map((response: Response) => response);
+    }
+
     /**
      * Get general wallet info from the API once.
      */


### PR DESCRIPTION
This code change is to handle different currencies than STRAT for the sidechains project.
I am not sure wether the code that sets the currencies in getCurrentNetwork() in file login.component.ts should be changed too, as it doesn't seem to have impact
When a node doesn't have a sidechain feature, then the API call will simply return a 404 and we can use the previous logic