### PR TITLE
Fixes error when no transactions are returned

### DIFF
--- a/FullNode.UI/src/app/wallet/dashboard/dashboard.component.ts
+++ b/FullNode.UI/src/app/wallet/dashboard/dashboard.component.ts
@@ -128,7 +128,7 @@ export class DashboardComponent implements OnInit {
         response => {
           if (response.status >= 200 && response.status < 400) {
             //TO DO - add account feature instead of using first entry in array
-            if (response.json().history[0].transactionsHistory.length > 0) {
+            if (response.json().history && response.json().history[0].transactionsHistory.length > 0) {
               historyResponse = response.json().history[0].transactionsHistory;
               this.getTransactionInfo(historyResponse);
             }

--- a/FullNode.UI/src/app/wallet/dashboard/dashboard.component.ts
+++ b/FullNode.UI/src/app/wallet/dashboard/dashboard.component.ts
@@ -128,7 +128,7 @@ export class DashboardComponent implements OnInit {
         response => {
           if (response.status >= 200 && response.status < 400) {
             //TO DO - add account feature instead of using first entry in array
-            if (response.json().history && response.json().history[0].transactionsHistory.length > 0) {
+            if (!!response.json().history && response.json().history[0].transactionsHistory.length > 0) {
               historyResponse = response.json().history[0].transactionsHistory;
               this.getTransactionInfo(historyResponse);
             }

--- a/FullNode.UI/src/app/wallet/history/history.component.ts
+++ b/FullNode.UI/src/app/wallet/history/history.component.ts
@@ -55,7 +55,7 @@ export class HistoryComponent {
         response => {
           if (response.status >= 200 && response.status < 400) {
             //TO DO - add account feature instead of using first entry in array
-            if (response.json().history && response.json().history[0].transactionsHistory.length > 0) {
+            if (!!response.json().history && response.json().history[0].transactionsHistory.length > 0) {
               historyResponse = response.json().history[0].transactionsHistory;
               this.getTransactionInfo(historyResponse);
             }

--- a/FullNode.UI/src/app/wallet/history/history.component.ts
+++ b/FullNode.UI/src/app/wallet/history/history.component.ts
@@ -55,7 +55,7 @@ export class HistoryComponent {
         response => {
           if (response.status >= 200 && response.status < 400) {
             //TO DO - add account feature instead of using first entry in array
-            if (response.json().history[0].transactionsHistory.length > 0) {
+            if (response.json().history && response.json().history[0].transactionsHistory.length > 0) {
               historyResponse = response.json().history[0].transactionsHistory;
               this.getTransactionInfo(historyResponse);
             }


### PR DESCRIPTION
If the API returns no transactions `response.json().history` is not an array, so length method causes error.